### PR TITLE
Update macOS and FreeBSD X11 headers directory

### DIFF
--- a/src/build
+++ b/src/build
@@ -103,12 +103,12 @@ if [ -z "$MAKEFILE" ] ; then
         X11_MAKELIB=/usr/X11R6/lib
     elif [ $PLATFORM = "Darwin" ] ; then
         MAKEBAS=darwin
-        X11_MAKEINC=/usr/X11R6/include
-        X11_MAKELIB=/usr/X11R6/lib
+        X11_MAKEINC=/opt/X11/include
+        X11_MAKELIB=/opt/X11/lib
     elif [ $PLATFORM = "FreeBSD" ] ; then
         MAKEBAS=freebsd
-        X11_MAKEINC=/usr/X11R6/include
-        X11_MAKELIB=/usr/X11R6/lib
+        X11_MAKEINC=/usr/local/include
+        X11_MAKELIB=/usr/local/lib
     elif [ $PLATFORM = "HP-UX" ] ; then
         X11_MAKEINC=/usr/include/X11R6
         X11_MAKELIB=/usr/lib/X11R6

--- a/src/darwin.gmk
+++ b/src/darwin.gmk
@@ -47,14 +47,14 @@ CDEBUG        =	-Wall -g
 COPTIMISE     =	-Wall -O3 -DNDEBUG=1 -Wno-uninitialized
 CDEFS         = -D_DARWIN -I.
 CONSOLE_DEFS  = -D_ME_CONSOLE
-WINDOW_DEFS   = $(MAKEWINDEFS) -D_ME_WINDOW -I/usr/X11R6/include
+WINDOW_DEFS   = $(MAKEWINDEFS) -D_ME_WINDOW -I/opt/X11/include
 NANOEMACS_DEFS= -D_NANOEMACS
 LDDEBUG       =
 LDOPTIMISE    =
 LDFLAGS       =
 LIBS          = -lz
 CONSOLE_LIBS  = -ltermcap
-WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/X11R6/lib -lX11
+WINDOW_LIBS   = $(MAKEWINLIBS) -L/opt/X11/lib -lX11
 #
 # Rules
 .SUFFIXES: .c .oc .ow .ob .on .ov .oe .odc .odw .odb .odn .odv .ode

--- a/src/freebsd.gmk
+++ b/src/freebsd.gmk
@@ -47,14 +47,14 @@ CDEBUG        =	-Wall -g
 COPTIMISE     =	-Wall -O3 -DNDEBUG=1 -Wno-uninitialized
 CDEFS         = -D_FREEBSD -I.
 CONSOLE_DEFS  = -D_ME_CONSOLE
-WINDOW_DEFS   = $(MAKEWINDEFS) -D_ME_WINDOW -I/usr/X11R6/include
+WINDOW_DEFS   = $(MAKEWINDEFS) -D_ME_WINDOW -I/usr/local/include
 NANOEMACS_DEFS= -D_NANOEMACS
 LDDEBUG       =
 LDOPTIMISE    =
 LDFLAGS       =
 LIBS          = -lz
 CONSOLE_LIBS  = -ltermcap
-WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/X11R6/lib -lX11
+WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/local/lib -lX11
 #
 # Rules
 .SUFFIXES: .c .oc .ow .ob .on .ov .oe .odc .odw .odb .odn .odv .ode

--- a/src/freebsd.mak
+++ b/src/freebsd.mak
@@ -47,14 +47,14 @@ CDEBUG        =	-g
 COPTIMISE     =	-O2 -DNDEBUG=1
 CDEFS         = -D_FREEBSD -I.
 CONSOLE_DEFS  = -D_ME_CONSOLE
-WINDOW_DEFS   = $(MAKEWINDEFS) -D_ME_WINDOW -I/usr/X11R6/include
+WINDOW_DEFS   = $(MAKEWINDEFS) -D_ME_WINDOW -I/usr/local/include
 NANOEMACS_DEFS= -D_NANOEMACS
 LDDEBUG       =
 LDOPTIMISE    =
 LDFLAGS       =
 LIBS          = -lz
 CONSOLE_LIBS  = -ltermcap
-WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/X11R6/lib -lX11
+WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/local/lib -lX11
 #
 # Rules
 .SUFFIXES: .c .oc .ow .ob .on .ov .oe .odc .odw .odb .odn .odv .ode


### PR DESCRIPTION
Both macOS/OS X and FreeBSD have changed their place of X11 header files, these must be updated  in `build` script and make files.