### PR TITLE
update openbsd.gmk

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -60,7 +60,7 @@ BUILD
             *  linux26.gmk Linux 2.6 kernels using GNU tools 
             *  mingw.gmk minGW http://www.MinGW.org using GNU tools. 
             *  osf1.gmk OSF1 using GNU tools. 
-            *  openbsd.gmk OpenBSD using GNU tools. 
+            *  openbsd.gmk OpenBSD using base tools. 
             *  openstep.mak Openstep 4.2 on NeXTstep (BSD 4.3). 
             *  sunos5.gmak Sun Solaris 5.5/6/7/8/9/10 using GNU tools 
             *  sunos5.mak Sun Solaris 5.6/7/8/9/10 native 

--- a/src/openbsd.gmk
+++ b/src/openbsd.gmk
@@ -41,7 +41,7 @@ INSTPROGFLAGS = -s -o root -g root -m 0775
 # Local Definitions
 CP            = cp
 RM            = rm -f
-CC            = gcc
+CC            = cc
 LD            = $(CC)
 STRIP         =	strip
 INSTALL       =	install
@@ -54,7 +54,7 @@ NANOEMACS_DEFS= -D_NANOEMACS
 LDDEBUG       =
 LDOPTIMISE    =
 LDFLAGS       =
-LIBS          =
+LIBS          = -lz
 CONSOLE_LIBS  = -ltermcap
 WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/X11R6/lib -lX11
 #
@@ -99,10 +99,10 @@ WINDOW_LIBS   = $(MAKEWINLIBS) -L/usr/X11R6/lib -lX11
 	$(CC) $(CDEBUG) $(CDEFS) $(NANOEMACS_DEFS) $(CONSOLE_DEFS) $(WINDOW_DEFS) $(MAKECDEFS) -o $@ -c $<
 #
 # Source files
-STDHDR	= ebind.h edef.h eextrn.h efunc.h emain.h emode.h eprint.h \
+STDHDR	= bfs.h ebind.h edef.h eextrn.h efunc.h emain.h emode.h eprint.h \
 	  esearch.h eskeys.h estruct.h eterm.h evar.h evers.h eopt.h \
 	  ebind.def efunc.def eprint.def evar.def etermcap.def emode.def eskeys.def
-STDSRC	= abbrev.c basic.c bind.c buffer.c crypt.c dirlist.c display.c \
+STDSRC	= abbrev.c basic.c bfs.c bind.c buffer.c crypt.c dirlist.c display.c \
 	  eval.c exec.c file.c fileio.c frame.c hilight.c history.c input.c \
 	  isearch.c key.c line.c macro.c main.c narrow.c next.c osd.c \
 	  print.c random.c regex.c region.c registry.c search.c spawn.c \


### PR DESCRIPTION
trivial fixes so that `make -f openbsd.gmk` works out-of-the-box now.  It doesn't even need GNU make.
I have only played a little with it, but builds fine and seems to work (the edits were done using the GUI :-)

Thanks,